### PR TITLE
GameAccount 영속성 계층 수정

### DIFF
--- a/src/main/java/edu/flab/member/domain/GameAccount.java
+++ b/src/main/java/edu/flab/member/domain/GameAccount.java
@@ -15,14 +15,14 @@ import lombok.ToString;
 public class GameAccount {
 	private Long id;
 	private Long memberId;
-	private String nickname;
-	private String loginId;
-	private RankTier rankTier;
+	private String nickname;    // 리그오브레전드 닉네임
+	private String lolLoginId;  // 리그오브레전드 로그인 아이디
+	private RankTier rankTier;  // 리그오브레전드 랭크 티어
 
-	public GameAccount(Long id, Long memberId, String nickname, String loginId) {
+	public GameAccount(Long id, Long memberId, String nickname, String lolLoginId) {
 		this.id = id;
 		this.memberId = memberId;
 		this.nickname = nickname;
-		this.loginId = loginId;
+		this.lolLoginId = lolLoginId;
 	}
 }

--- a/src/main/java/edu/flab/member/domain/GameAccount.java
+++ b/src/main/java/edu/flab/member/domain/GameAccount.java
@@ -1,18 +1,28 @@
 package edu.flab.member.domain;
 
 import edu.flab.global.vo.RankTier;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 @ToString
-@Getter
 @EqualsAndHashCode
+@AllArgsConstructor
 @Builder
+@Getter
 public class GameAccount {
 	private Long id;
-	private String loginId;
+	private Long memberId;
 	private String nickname;
+	private String loginId;
 	private RankTier rankTier;
+
+	public GameAccount(Long id, Long memberId, String nickname, String loginId) {
+		this.id = id;
+		this.memberId = memberId;
+		this.nickname = nickname;
+		this.loginId = loginId;
+	}
 }

--- a/src/main/java/edu/flab/member/dto/GameAccountUpdateDto.java
+++ b/src/main/java/edu/flab/member/dto/GameAccountUpdateDto.java
@@ -4,5 +4,5 @@ import edu.flab.global.vo.RankTier;
 import lombok.Builder;
 
 @Builder
-public record GameAccountUpdateDto(Long id, String loginId, String nickname, RankTier rankTier) {
+public record GameAccountUpdateDto(Long id, Long memberId, String loginId, String nickname, RankTier rankTier) {
 }

--- a/src/main/java/edu/flab/member/dto/GameAccountUpdateDto.java
+++ b/src/main/java/edu/flab/member/dto/GameAccountUpdateDto.java
@@ -4,5 +4,5 @@ import edu.flab.global.vo.RankTier;
 import lombok.Builder;
 
 @Builder
-public record GameAccountUpdateDto(Long id, Long memberId, String loginId, String nickname, RankTier rankTier) {
+public record GameAccountUpdateDto(Long id, Long memberId, String lolLoginId, String nickname, RankTier rankTier) {
 }

--- a/src/main/java/edu/flab/member/repository/GameAccountMapper.java
+++ b/src/main/java/edu/flab/member/repository/GameAccountMapper.java
@@ -15,5 +15,5 @@ public interface GameAccountMapper {
 
 	Optional<GameAccount> findById(Long id);
 
-	Optional<GameAccount> findByLoginId(String loginId);
+	Optional<GameAccount> findByLoginId(String lolLoginId);
 }

--- a/src/main/resources/edu/flab/member/repository/GameAccountMapper.xml
+++ b/src/main/resources/edu/flab/member/repository/GameAccountMapper.xml
@@ -4,13 +4,13 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="edu.flab.member.repository.GameAccountMapper">
     <insert id="save" useGeneratedKeys="true" keyProperty="id" keyColumn="id">
-        INSERT INTO game_account (login_id, member_id, nickname, rank_tier_group, rank_tier_level)
-        VALUES (#{loginId}, #{memberId}, #{nickname}, #{rankTier.group}, #{rankTier.level})
+        INSERT INTO game_account (lol_login_id, member_id, nickname, rank_tier_group, rank_tier_level)
+        VALUES (#{lolLoginId}, #{memberId}, #{nickname}, #{rankTier.group}, #{rankTier.level})
     </insert>
 
     <update id="update">
         UPDATE game_account
-        SET login_id=#{loginId},
+        SET lol_login_id=#{lolLoginId},
             member_id=#{memberId},
             nickname=#{nickname},
             rank_tier_group=#{rankTier.group},
@@ -22,7 +22,7 @@
         SELECT id              AS gameAccountId,
                member_id       AS memberId,
                nickname        AS nickname,
-               login_id        AS loginId,
+               lol_login_id    AS lolLoginId,
                rank_tier_group AS rankTierGroup,
                rank_tier_level AS rankTierLevel
         FROM game_account
@@ -33,11 +33,11 @@
         SELECT id              AS gameAccountId,
                member_id       AS memberId,
                nickname        AS nickname,
-               login_id        AS loginId,
+               lol_login_id    AS lolLoginId,
                rank_tier_group AS rankTierGroup,
                rank_tier_level AS rankTierLevel
         FROM game_account
-        WHERE login_id = #{loginId}
+        WHERE lol_login_id = #{lolLoginId}
     </select>
 
     <resultMap id="gameAccountResultMap" type="GameAccount">
@@ -45,7 +45,7 @@
             <idArg column="gameAccountId" javaType="Long"/>
             <arg column="memberId" javaType="Long"/>
             <arg column="nickname" javaType="String"/>
-            <arg column="loginId" javaType="String"/>
+            <arg column="lolLoginId" javaType="String"/>
         </constructor>
         <association property="rankTier" javaType="RankTier">
             <result column="rank_tier_group" property="group"/>

--- a/src/main/resources/edu/flab/member/repository/GameAccountMapper.xml
+++ b/src/main/resources/edu/flab/member/repository/GameAccountMapper.xml
@@ -4,13 +4,14 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="edu.flab.member.repository.GameAccountMapper">
     <insert id="save" useGeneratedKeys="true" keyProperty="id" keyColumn="id">
-        INSERT INTO game_account (login_id, nickname, rank_tier_group, rank_tier_level)
-        VALUES (#{loginId}, #{nickname}, #{rankTier.group}, #{rankTier.level})
+        INSERT INTO game_account (login_id, member_id, nickname, rank_tier_group, rank_tier_level)
+        VALUES (#{loginId}, #{memberId}, #{nickname}, #{rankTier.group}, #{rankTier.level})
     </insert>
 
     <update id="update">
         UPDATE game_account
         SET login_id=#{loginId},
+            member_id=#{memberId},
             nickname=#{nickname},
             rank_tier_group=#{rankTier.group},
             rank_tier_level=#{rankTier.level}
@@ -18,21 +19,34 @@
     </update>
 
     <select id="findById" resultMap="gameAccountResultMap">
-        SELECT id, login_id, nickname, rank_tier_group, rank_tier_level
+        SELECT id              AS gameAccountId,
+               member_id       AS memberId,
+               nickname        AS nickname,
+               login_id        AS loginId,
+               rank_tier_group AS rankTierGroup,
+               rank_tier_level AS rankTierLevel
         FROM game_account
         WHERE id = #{id}
     </select>
 
     <select id="findByLoginId" resultMap="gameAccountResultMap">
-        SELECT id, login_id, nickname, rank_tier_group, rank_tier_level
+        SELECT id              AS gameAccountId,
+               member_id       AS memberId,
+               nickname        AS nickname,
+               login_id        AS loginId,
+               rank_tier_group AS rankTierGroup,
+               rank_tier_level AS rankTierLevel
         FROM game_account
         WHERE login_id = #{loginId}
     </select>
 
     <resultMap id="gameAccountResultMap" type="GameAccount">
-        <result column="id" property="id"/>
-        <result column="login_id" property="loginId"/>
-        <result column="nickname" property="nickname"/>
+        <constructor>
+            <idArg column="gameAccountId" javaType="Long"/>
+            <arg column="memberId" javaType="Long"/>
+            <arg column="nickname" javaType="String"/>
+            <arg column="loginId" javaType="String"/>
+        </constructor>
         <association property="rankTier" javaType="RankTier">
             <result column="rank_tier_group" property="group"/>
             <result column="rank_tier_level" property="level"/>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,30 +1,30 @@
+-- 회원 테이블
+CREATE TABLE member
+(
+    id          BIGINT NOT NULL AUTO_INCREMENT,
+    email       VARCHAR(320) UNIQUE,
+    `password`  VARCHAR(32),
+    profile_url VARCHAR(200),
+    judge_point INT     DEFAULT 0,
+    deleted     BOOLEAN DEFAULT FALSE,
+
+    PRIMARY KEY (id)
+);
+
 -- 리그오브레전드 계정 테이블
 CREATE TABLE game_account
 (
     id              BIGINT NOT NULL AUTO_INCREMENT,
+    member_id       BIGINT,
     login_id        VARCHAR(24) UNIQUE,
     nickname        VARCHAR(16) UNIQUE,
     rank_tier_group VARCHAR(16),
     rank_tier_level TINYINT CHECK (0 < rank_tier_level AND rank_tier_level < 5),
 
-    PRIMARY KEY (id)
-);
-
--- 회원 테이블
-CREATE TABLE member
-(
-    id              BIGINT NOT NULL AUTO_INCREMENT,
-    game_account_id BIGINT,
-    profile_url     VARCHAR(200),
-    email           VARCHAR(320),
-    `password`      VARCHAR(32),
-    judge_point     INT        DEFAULT 0,
-    deleted         TINYINT(1) DEFAULT 0,
-
     PRIMARY KEY (id),
 
-    FOREIGN KEY (game_account_id)
-        REFERENCES game_account (id)
+    FOREIGN KEY (member_id)
+        REFERENCES member (id)
 );
 
 -- 인게임 정보 테이블

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE game_account
 (
     id              BIGINT NOT NULL AUTO_INCREMENT,
     member_id       BIGINT,
-    login_id        VARCHAR(24) UNIQUE,
+    lol_login_id    VARCHAR(24) UNIQUE,
     nickname        VARCHAR(16) UNIQUE,
     rank_tier_group VARCHAR(16),
     rank_tier_level TINYINT CHECK (0 < rank_tier_level AND rank_tier_level < 5),

--- a/src/test/java/edu/flab/member/repository/GameAccountMapperTest.java
+++ b/src/test/java/edu/flab/member/repository/GameAccountMapperTest.java
@@ -22,7 +22,7 @@ class GameAccountMapperTest {
 	void 아이디_조회() {
 		// given
 		GameAccount gameAccount = GameAccount.builder()
-			.loginId("login12345")
+			.lolLoginId("login12345")
 			.nickname("hide on bush")
 			.rankTier(RankTier.CHALLENGER)
 			.build();
@@ -40,14 +40,14 @@ class GameAccountMapperTest {
 	void 롤계정_조회() {
 		// given
 		GameAccount gameAccount = GameAccount.builder()
-			.loginId("login1234")
+			.lolLoginId("login1234")
 			.nickname("hide on bush")
 			.rankTier(RankTier.CHALLENGER)
 			.build();
 
 		// when
 		sut.save(gameAccount);
-		GameAccount findGameAccount = sut.findByLoginId(gameAccount.getLoginId()).orElseThrow();
+		GameAccount findGameAccount = sut.findByLoginId(gameAccount.getLolLoginId()).orElseThrow();
 
 		// then
 		assertThat(findGameAccount).isEqualTo(gameAccount);
@@ -59,7 +59,7 @@ class GameAccountMapperTest {
 
 		// given
 		GameAccount gameAccount = GameAccount.builder()
-			.loginId("login1234")
+			.lolLoginId("login1234")
 			.nickname("hide on bush")
 			.rankTier(RankTier.CHALLENGER)
 			.build();
@@ -69,7 +69,7 @@ class GameAccountMapperTest {
 		// when
 		GameAccountUpdateDto dto = GameAccountUpdateDto.builder()
 			.id(gameAccount.getId())
-			.loginId("newLogin1234")
+			.lolLoginId("newLogin1234")
 			.nickname("show maker")
 			.rankTier(RankTier.CHALLENGER)
 			.build();


### PR DESCRIPTION
# 📖  작업 내용

## GameAccount 엔티티에 memberId 컬럼 추가
- 기존에는 member와 game_account 간의 연관관계를 member에서 관리하였음.
- member 엔티티가 game_account_id를 갖고 있었지만, member 엔티티가 game_account 테이블에 비해 많이 사용될 것으로 예상되어, member 엔티티의 필드를 하나라도 줄이고자 함.

## GameAccountMapper.xml 수정
- memberId 컬럼 추가
- select 문의 alias 추가 => 추후 join 문에서 다른 테이블과 공통 컬럼명 헷갈림 방지
- gameAccountResultMap 수정 => MemberMapper.xml에서 gameAccountResultMap 을 재사용하는 과정에서 gameAccountResultMap 에 생성자 태그로 생성자를 명시해주지 않으면 에러가 발생함 (이유 확인중)

## GameAccountUpdate.dto 수정
- memberId 컬럼 추가
