### PR TITLE
JudgePoint 업데이트 서비스

### DIFF
--- a/src/main/java/edu/flab/member/domain/Member.java
+++ b/src/main/java/edu/flab/member/domain/Member.java
@@ -53,4 +53,8 @@ public class Member {
 	public RankScore updateRankScore() {
 		return rankScore = RankScore.calc(this);
 	}
+
+	public void updateJudgePoint(int judgePoint) {
+		this.judgePoint = judgePoint;
+	}
 }

--- a/src/main/java/edu/flab/member/dto/MemberJudgePointUpdateDto.java
+++ b/src/main/java/edu/flab/member/dto/MemberJudgePointUpdateDto.java
@@ -1,6 +1,5 @@
 package edu.flab.member.dto;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +13,6 @@ import lombok.NoArgsConstructor;
 public class MemberJudgePointUpdateDto {
 	private Long id;
 
-	@NotNull
-	private Integer judgePoint;
+	private int judgePoint;
 }
 

--- a/src/main/java/edu/flab/member/dto/MemberJudgePointUpdateDto.java
+++ b/src/main/java/edu/flab/member/dto/MemberJudgePointUpdateDto.java
@@ -1,5 +1,7 @@
 package edu.flab.member.dto;
 
+import org.hibernate.validator.constraints.Range;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +15,7 @@ import lombok.NoArgsConstructor;
 public class MemberJudgePointUpdateDto {
 	private Long id;
 
+	@Range(min = 0, max = Integer.MAX_VALUE)
 	private int judgePoint;
 }
 

--- a/src/main/java/edu/flab/member/service/MemberJudgePointService.java
+++ b/src/main/java/edu/flab/member/service/MemberJudgePointService.java
@@ -1,0 +1,36 @@
+package edu.flab.member.service;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import edu.flab.member.domain.Member;
+import edu.flab.member.dto.MemberJudgePointUpdateDto;
+import edu.flab.member.repository.MemberMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberJudgePointService {
+
+	private final MemberMapper memberMapper;
+
+	@Transactional
+	public Member updateJudgePoint(MemberJudgePointUpdateDto dto) {
+		Member member = memberMapper.findActiveMemberById(dto.getId())
+			.orElseThrow(() -> new NoSuchElementException("회원이 존재하지 않습니다."));
+
+		int beforeUpdate = member.getJudgePoint();
+
+		memberMapper.updateJudgePoint(dto);
+		member.updateJudgePoint(dto.getJudgePoint());
+
+		log.info("JudgePoint 업데이트 완료 <회원 이메일: {}> <변경 내역: {} → {}>", member.getEmail(), beforeUpdate,
+			member.getJudgePoint());
+
+		return member;
+	}
+}

--- a/src/test/java/edu/flab/member/service/MemberJudgePointServiceTest.java
+++ b/src/test/java/edu/flab/member/service/MemberJudgePointServiceTest.java
@@ -1,0 +1,44 @@
+package edu.flab.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import edu.flab.member.domain.Member;
+import edu.flab.member.dto.MemberJudgePointUpdateDto;
+import edu.flab.member.repository.MemberMapper;
+
+@ExtendWith(MockitoExtension.class)
+class MemberJudgePointServiceTest {
+
+	@InjectMocks
+	private MemberJudgePointService sut;
+
+	@Mock
+	private MemberMapper memberMapper;
+
+	@Test
+	@DisplayName("회원의 JudgePoint 를 변경할 수 있다")
+	void test1() {
+		// given
+		Member member = Member.builder().email("example@example.com").password("1234").build();
+		MemberJudgePointUpdateDto dto = MemberJudgePointUpdateDto.builder().id(1L).judgePoint(1000).build();
+		Mockito.when(memberMapper.findActiveMemberById(1L)).thenReturn(Optional.of(member));
+
+		// when
+		Member updatedMember = sut.updateJudgePoint(dto);
+
+		// then
+		Mockito.verify(memberMapper).findActiveMemberById(1L);
+		Mockito.verify(memberMapper).updateJudgePoint(dto);
+		assertThat(updatedMember.getJudgePoint()).isEqualTo(dto.getJudgePoint());
+	}
+}


### PR DESCRIPTION
## 📖 주요 작업 내용

### Member 클래스
- updateJudgePoint 메서드 추가
   - Member 도메인 클래스의 judgePoint 멤버변수를 변경시키는 메서드

<br/>

### MemberJudgePointService 클래스
- updateJudgePoint 메서드 추가
   - Member id를 전달받아, Member 도메인 클래스 및 DB 테이블의 judgePoint 컬럼을 변경시키는 서비스 

