### PR TITLE
회원가입 정보 변경

### DIFF
--- a/backend/module-api-app/src/main/java/edu/flab/member/controller/MemberController.java
+++ b/backend/module-api-app/src/main/java/edu/flab/member/controller/MemberController.java
@@ -16,10 +16,13 @@ import edu.flab.member.dto.MemberSignUpDto;
 import edu.flab.member.service.MemberLoginService;
 import edu.flab.member.service.MemberRankFindService;
 import edu.flab.member.service.MemberSignUpService;
+import edu.flab.web.response.SuccessResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 public class MemberController {
@@ -29,13 +32,15 @@ public class MemberController {
 
 	@ResponseStatus(HttpStatus.OK)
 	@PostMapping("/signUp")
-	public void signUp(@RequestBody @Valid MemberSignUpDto dto) {
+	public SuccessResponse<Void> signUp(@RequestBody @Valid MemberSignUpDto dto) {
 		memberSignUpService.signUp(dto);
+		return SuccessResponse.ok();
 	}
 
 	@PostMapping("/login")
-	public void login(HttpServletRequest request, @RequestBody @Valid MemberLoginDto dto) {
+	public SuccessResponse<Void> login(HttpServletRequest request, @RequestBody @Valid MemberLoginDto dto) {
 		memberLoginService.login(request, dto);
+		return SuccessResponse.ok();
 	}
 
 	@ResponseStatus(HttpStatus.OK)

--- a/backend/module-api-app/src/main/java/edu/flab/member/dto/MemberSignUpDto.java
+++ b/backend/module-api-app/src/main/java/edu/flab/member/dto/MemberSignUpDto.java
@@ -27,18 +27,10 @@ public class MemberSignUpDto {
 	@Password
 	private String password;
 
-	@URL
-	@Length(max = 200)
-	private String profileUrl;
-
 	@NotBlank
 	@Length(max = 16)
-	private String nickname;
-
-	@NotBlank
-	@Length(max = 24)
 	private String gameLoginId;
 
-	@NotNull
-	private LolTier lolTier;
+	@NotBlank
+	private String position;
 }

--- a/backend/module-api-app/src/main/java/edu/flab/member/service/MemberSignUpService.java
+++ b/backend/module-api-app/src/main/java/edu/flab/member/service/MemberSignUpService.java
@@ -4,13 +4,18 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import edu.flab.exception.BusinessException;
 import edu.flab.member.domain.GameAccount;
+import edu.flab.member.domain.GamePosition;
 import edu.flab.member.domain.Member;
 import edu.flab.member.dto.MemberSignUpDto;
 import edu.flab.member.repository.GameAccountMapper;
 import edu.flab.member.repository.MemberMapper;
+import edu.flab.web.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class MemberSignUpService {
@@ -20,17 +25,19 @@ public class MemberSignUpService {
 
 	@Transactional
 	public Member signUp(MemberSignUpDto dto) {
+		if (isAlreadyExist(dto.getEmail(), dto.getGameLoginId())) {
+			throw new BusinessException(ErrorCode.DUPLICATE_ACCOUNT);
+		}
+
 		Member member = Member.builder()
 			.email(dto.getEmail())
 			.password(encryptPassword(dto.getPassword()))
-			.profileUrl(dto.getProfileUrl())
 			.build();
 
 		GameAccount gameAccount = GameAccount.builder()
 			.memberId(member.getId())
 			.lolLoginId(dto.getGameLoginId())
-			.nickname(dto.getNickname())
-			.lolTier(dto.getLolTier())
+			.position(GamePosition.of(dto.getPosition()))
 			.build();
 
 		memberMapper.save(member);
@@ -38,6 +45,11 @@ public class MemberSignUpService {
 		gameAccountMapper.save(gameAccount);
 
 		return member;
+	}
+
+	private boolean isAlreadyExist(String email, String gameLoginId) {
+		return gameAccountMapper.findByLoginId(gameLoginId).isPresent() || memberMapper.findActiveMemberByEmail(email)
+			.isPresent();
 	}
 
 	private String encryptPassword(String password) {

--- a/backend/module-api-app/src/test/java/edu/flab/election/controller/ElectionControllerTest.java
+++ b/backend/module-api-app/src/test/java/edu/flab/election/controller/ElectionControllerTest.java
@@ -1,7 +1,5 @@
 package edu.flab.election.controller;
 
-import static edu.flab.member.domain.LolTier.Color.*;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +27,6 @@ import edu.flab.election.dto.ElectionRegisterRequestDto;
 import edu.flab.election.dto.ElectionRegisterResponseDto;
 import edu.flab.election.service.ElectionFindService;
 import edu.flab.member.controller.MemberController;
-import edu.flab.member.domain.LolTierUtil;
 import edu.flab.member.domain.Member;
 import edu.flab.member.dto.MemberSignUpDto;
 import edu.flab.member.service.MemberSignUpService;
@@ -75,19 +72,13 @@ class ElectionControllerTest {
 		MemberSignUpDto hostSignUpDto = MemberSignUpDto.builder()
 			.email("host@example.com")
 			.password("aB#12345")
-			.profileUrl("https://cloud.example.com/bucket/profile_image1.jpg")
 			.gameLoginId("lolId1111")
-			.nickname("hide on bush")
-			.lolTier(LolTierUtil.createHighTier(CHALLENGER, 1100))
 			.build();
 
 		MemberSignUpDto participantSignUpDto = MemberSignUpDto.builder()
 			.email("participant@example.com")
 			.password("aB#12345")
-			.profileUrl("https://cloud.example.com/bucket/profile_image2.jpg")
 			.gameLoginId("lolId2222")
-			.nickname("show maker")
-			.lolTier(LolTierUtil.createHighTier(CHALLENGER, 1000))
 			.build();
 
 		Member hostMember = memberSignUpService.signUp(hostSignUpDto);

--- a/backend/module-api-app/src/test/java/edu/flab/member/controller/MemberControllerTest.java
+++ b/backend/module-api-app/src/test/java/edu/flab/member/controller/MemberControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.flab.member.domain.GamePosition;
 import edu.flab.member.domain.LolTier;
 import edu.flab.member.domain.LolTierUtil;
 import edu.flab.member.dto.MemberLoginDto;
@@ -51,10 +52,8 @@ class MemberControllerTest {
 		MemberSignUpDto signUpDto = MemberSignUpDto.builder()
 			.email("admin@example.com")
 			.password("aB#12345")
-			.profileUrl("https://cloud.example.com/bucket/profile_image.jpg")
 			.gameLoginId("lolId1234")
-			.nickname("hide on bush")
-			.lolTier(challenger)
+			.position("MID")
 			.build();
 
 		mock.perform(MockMvcRequestBuilders.post("/signUp")
@@ -69,10 +68,7 @@ class MemberControllerTest {
 		MemberSignUpDto signUpDto = MemberSignUpDto.builder()
 			.email("admin@example.com")
 			.password("aB#")
-			.profileUrl("https://cloud.example.com/bucket/profile_image.jpg")
 			.gameLoginId("lolId1234")
-			.nickname("hide on bush")
-			.lolTier(challenger)
 			.build();
 
 		mock.perform(MockMvcRequestBuilders.post("/signUp")
@@ -87,10 +83,8 @@ class MemberControllerTest {
 		MemberSignUpDto signUpDto = MemberSignUpDto.builder()
 			.email("admin@example.com")
 			.password("aB#12345")
-			.profileUrl("https://cloud.example.com/bucket/profile_image.jpg")
 			.gameLoginId("lolId1234")
-			.nickname("hide on bush")
-			.lolTier(LolTierUtil.createHighTier(CHALLENGER, 1400))
+			.position("MID")
 			.build();
 
 		MemberLoginDto loginDto = MemberLoginDto.builder()
@@ -116,10 +110,8 @@ class MemberControllerTest {
 		MemberSignUpDto signUpDto = MemberSignUpDto.builder()
 			.email("admin@example.com")
 			.password("aB#12345")
-			.profileUrl("https://cloud.example.com/bucket/profile_image.jpg")
 			.gameLoginId("lolId1234")
-			.nickname("hide on bush")
-			.lolTier(LolTierUtil.createHighTier(CHALLENGER, 1400))
+			.position("MID")
 			.build();
 
 		MemberLoginDto loginDto = MemberLoginDto.builder()

--- a/backend/module-api-app/src/test/java/edu/flab/member/service/MemberSignUpServiceTest.java
+++ b/backend/module-api-app/src/test/java/edu/flab/member/service/MemberSignUpServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import edu.flab.member.domain.GameAccount;
+import edu.flab.member.domain.GamePosition;
 import edu.flab.member.domain.LolTier;
 import edu.flab.member.domain.LolTierUtil;
 import edu.flab.member.domain.Member;
@@ -43,10 +44,7 @@ class MemberSignUpServiceTest {
 		MemberSignUpDto dto = MemberSignUpDto.builder()
 			.email("admin@example.com")
 			.password("12341234")
-			.profileUrl("cloud.naver.com/bucket/example_profile.jpg")
 			.gameLoginId("user12345")
-			.nickname("admin")
-			.lolTier(challenger)
 			.build();
 
 		doNothing().when(memberMapper).save(any(Member.class));
@@ -59,13 +57,12 @@ class MemberSignUpServiceTest {
 		// then
 		GameAccount gameAccount = GameAccount.builder()
 			.lolLoginId(dto.getGameLoginId())
-			.nickname(dto.getNickname())
-			.lolTier(dto.getLolTier()).build();
+			.position(GamePosition.NONE)
+			.build();
 
 		Member member = Member.builder()
 			.email(dto.getEmail())
 			.password("encrypted password")
-			.profileUrl(dto.getProfileUrl())
 			.gameAccount(gameAccount).build();
 
 		verify(memberMapper).save(member);

--- a/backend/module-core/src/main/java/edu/flab/web/response/ErrorCode.java
+++ b/backend/module-core/src/main/java/edu/flab/web/response/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Not supported method"),
 
 	// Member
-	WRONG_ACCOUNT(HttpStatus.UNAUTHORIZED, "Wrong Email or Password");
+	WRONG_ACCOUNT(HttpStatus.UNAUTHORIZED, "Wrong Email or Password"),
+	DUPLICATE_ACCOUNT(HttpStatus.CONFLICT, "Member Already Exists");
 
 	private final HttpStatusCode httpStatusCode;
 	private final String message;

--- a/backend/module-core/src/main/resources/schema.sql
+++ b/backend/module-core/src/main/resources/schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS game_account
     member_id      BIGINT,
     lol_login_id   VARCHAR(24) UNIQUE,
     nickname       VARCHAR(16) UNIQUE,
+    position       VARCHAR(16),
     lol_tier_color VARCHAR(16),
     lol_tier_level TINYINT CHECK (0 <= lol_tier_level AND lol_tier_level < 5),
     lol_tier_point INT,

--- a/backend/module-domain-member/src/main/java/edu/flab/member/domain/GameAccount.java
+++ b/backend/module-domain-member/src/main/java/edu/flab/member/domain/GameAccount.java
@@ -30,6 +30,8 @@ public class GameAccount {
 	private String lolLoginId;  // 리그오브레전드 계정 아이디
 
 	@NotNull
+	private GamePosition position;	// 리그오브레전드 포지션
+
 	private LolTier lolTier;    // 리그오브레전드 랭크 티어 정보
 
 	public GameAccount(Long id, Long memberId, String nickname, String lolLoginId) {

--- a/backend/module-domain-member/src/main/java/edu/flab/member/domain/GamePosition.java
+++ b/backend/module-domain-member/src/main/java/edu/flab/member/domain/GamePosition.java
@@ -1,0 +1,12 @@
+package edu.flab.member.domain;
+
+public enum GamePosition {
+	NONE, TOP, JUNGLE, MID, ADC, SUPPORT;
+
+	public static GamePosition of(String name) {
+		if (name == null) {
+			return NONE;
+		}
+		return GamePosition.valueOf(name);
+	}
+}

--- a/backend/module-domain-member/src/main/resources/edu/flab/member/repository/GameAccountMapper.xml
+++ b/backend/module-domain-member/src/main/resources/edu/flab/member/repository/GameAccountMapper.xml
@@ -4,15 +4,15 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="edu.flab.member.repository.GameAccountMapper">
     <insert id="save" useGeneratedKeys="true" keyProperty="id" keyColumn="id">
-        INSERT INTO game_account (lol_login_id, member_id, nickname, lol_tier_color, lol_tier_level, lol_tier_point)
-        VALUES (#{lolLoginId}, #{memberId}, #{nickname}, #{lolTier.color}, #{lolTier.level},
-                #{lolTier.point})
+        INSERT INTO game_account (lol_login_id, member_id, nickname, position)
+        VALUES (#{lolLoginId}, #{memberId}, #{nickname}, #{position})
     </insert>
 
     <update id="update">
         UPDATE game_account
         SET lol_login_id=#{lolLoginId},
             nickname=#{nickname},
+            position=#{position},
             lol_tier_color=#{lolTier.color},
             lol_tier_level=#{lolTier.level},
             lol_tier_point=#{lolTier.point}

--- a/backend/module-domain-member/src/main/resources/edu/flab/member/repository/MemberMapper.xml
+++ b/backend/module-domain-member/src/main/resources/edu/flab/member/repository/MemberMapper.xml
@@ -4,8 +4,8 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="edu.flab.member.repository.MemberMapper">
     <insert id="save" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO member (email, password, profile_url)
-        VALUES (#{email}, #{password}, #{profileUrl});
+        INSERT INTO member (email, password)
+        VALUES (#{email}, #{password});
     </insert>
 
     <update id="updatePassword">


### PR DESCRIPTION
## 📖 주요 작업 내용

- 포지션 정보 추가
- 롤티어 정보를 DB Insert 작업에서 제외하도록 수정
   - 언랭크 유저의 경우, 롤티어 정보가 존재하지 않을 수도 있다. 
   - 개선 방향
      1. 최초 가입시 해당 컬럼을 null로 DB에 정보를 등록한다.
      2. gameLoginId를 바탕으로 리그오브레전드 API를 이용하여 소환사 티어 정보를 검색한다.
      3. 검색에 성공하면, DB에서 티어정보를 수정한다.